### PR TITLE
Test for None to avoid an error

### DIFF
--- a/mutt-to-omnifocus.py
+++ b/mutt-to-omnifocus.py
@@ -22,11 +22,12 @@ def applescript_escape(string):
     """Applescript requires backslashes and double quotes to be escaped in 
     string.  This returns the escaped string.
     """
-    # Backslashes first (else you end up escaping your escapes)
-    string = string.replace('\\', '\\\\')
+    if string is not None:
+        # Backslashes first (else you end up escaping your escapes)
+        string = string.replace('\\', '\\\\')
 
-    # Then double quotes
-    string = string.replace('"', '\\"')
+        # Then double quotes
+        string = string.replace('"', '\\"')
 
     return string
 


### PR DESCRIPTION
Ran into a situation where a "None" string was getting sent to "applescript_escape" causing the string.replace to throw an error.  To correct this, I'm only running the replace if string is not None.
