### PR TITLE
Remove 'select tree 1' from AppleScript

### DIFF
--- a/mutt-to-omnifocus.py
+++ b/mutt-to-omnifocus.py
@@ -66,7 +66,6 @@ def send_to_omnifocus(params, quickentry=False):
                     tell quick entry
                         open
                         make new inbox task with properties {name: "%s", note:"%s"}
-                        select tree 1
                         set note expanded of tree 1 to true
                     end tell
                 end tell


### PR DESCRIPTION
Using OmniFocus 2.10 on macOS 10.11.5, this line causes the following error to appear:

`execution error: OmniFocus got an error: tree 1 of quick entry of default document doesn’t understand the “select” message. (-1708)`

If the line is removed, the note expands properly.

*(Sorry – had to recreate PR #2 using a new branch of my fork)*